### PR TITLE
feat: Update Swagger server URL in configuration

### DIFF
--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -19,7 +19,7 @@ const options = {
     },
     servers: [
       {
-        url: 'http://3.37.46.45:30300',
+        url: 'http://16.184.9.194:30300',
         description: 'API 서버'
       }
     ],


### PR DESCRIPTION
Replaced the outdated server URL with the new one to reflect the current API server address. This ensures the Swagger documentation points to the correct endpoint.