### PR TITLE
feat: Update CORS configuration to support additional origins

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,7 +13,7 @@ const app : Express = express();
 app.use(express.json());
 app.use(cookieParser());
 app.use(cors({
-    origin: 'http://localhost:3000',
+    origin: ['http://localhost:3000', 'http://uosludex.com', 'https://uosludex.com'],
     credentials: true,
     exposedHeaders: ["authorization", "set-cookie"]
 }));


### PR DESCRIPTION
Expanded the allowed origins in the CORS configuration to include `uosludex.com` and its HTTPS variant.